### PR TITLE
Fixed calendar header issue, where year was not showing as calendar header for initial rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,6 +79,7 @@
         </button>
       </div>
     </div>
+
     <div class="calender-header">
       <h1 class="calender-header-year"></h1>
     </div>

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ class Calendar {
           this.calendar += this.weeks_iterator(month, current_itr_month);
       }
       
+      
   }
 
   // Iterates for a whole month by dividing days into week, and returns completed month template
@@ -127,13 +128,14 @@ class Calendar {
 // Renderer call - Class Based
 
 function calendar_init(year = null) {
-    document.getElementsByClassName('calender-header-year')[0].innerHTML = document.getElementById('year-input').value;
+
   if (year === null){
       year = new Date().getFullYear()
   } else{
       year = Number(document.getElementById('year-input').value)
   }
-  let calendar = new Calendar(year);
+    let calendar = new Calendar(year);
+    document.getElementsByClassName('calender-header-year')[0].innerHTML = year;
   calendar.render_calendar()
 }
 calendar_init()


### PR DESCRIPTION
###  Fixed issue with calendar header, where `year` was not showing when first time loaded #27 

## Changes

> - Manipulated DOM inside calendar_init method to render `given or current year` as **calendar** **header**.