### PR TITLE
Fix: changed rectangular boxes on hover to circular boxes  #31

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -190,26 +190,12 @@ header nav .nav-right ul li a:hover {
   grid-template-columns: 14.2857142857% 14.2857142857% 14.2857142857% 14.2857142857% 14.2857142857% 14.2857142857% 14.2857142857%;
 }
 .month .week-days ul li {
-  display:inline-block;   //changed
+  display:inline-block;
   color: #777;
   font-size: 13px;
   text-align: center;
-  margin-bottom: 0.5em; //changed
-  padding: 0.5em 0.5em; // changed
-  border-radius: 100%;   // changed
-  border:2px solid #eee;  //changed
-  cursor: pointer;
-}
-
-.month .week-days ul li:nth-last-child(-n+2) {
-  display:inline-block;   //changed
-  color: #777;
-  font-size: 13px;
-  text-align: center;
-  margin-bottom: 0.5em; //changed
-  padding: 0.5em 0.5em; // changed
-  border-radius: 100%;   // changed
-  border:2px solid #eee;  //changed
+  padding: 1em 0.3em;
+  border-radius: 100%; /* Used 100% to make it circular */
   cursor: pointer;
 }
 
@@ -219,7 +205,7 @@ header nav .nav-right ul li a:hover {
 }
 
 .weekend-color {
-  color: var(--c-weekday-color) !important;
+  color: var(--c-weekend-color) !important;
 }
 
 .weekend-current-date, .weekend-color:hover {

--- a/css/index.css
+++ b/css/index.css
@@ -190,14 +190,29 @@ header nav .nav-right ul li a:hover {
   grid-template-columns: 14.2857142857% 14.2857142857% 14.2857142857% 14.2857142857% 14.2857142857% 14.2857142857% 14.2857142857%;
 }
 .month .week-days ul li {
+  display:inline-block;   //changed
   color: #777;
   font-size: 13px;
   text-align: center;
-  margin-bottom: 0.5em;
-  padding: 0.3em;
-  border-radius: 4px;
+  margin-bottom: 0.5em; //changed
+  padding: 0.5em 0.5em; // changed
+  border-radius: 100%;   // changed
+  border:2px solid #eee;  //changed
   cursor: pointer;
 }
+
+.month .week-days ul li:nth-last-child(-n+2) {
+  display:inline-block;   //changed
+  color: #777;
+  font-size: 13px;
+  text-align: center;
+  margin-bottom: 0.5em; //changed
+  padding: 0.5em 0.5em; // changed
+  border-radius: 100%;   // changed
+  border:2px solid #eee;  //changed
+  cursor: pointer;
+}
+
 .month .week-days ul li:hover {
   color: white !important;
   background: #343a40;


### PR DESCRIPTION
Fixes : #31 

This PR resolves the issue described to change the rectangular boxes to circular on hover


Changed the previous Rectangular block which looks like this 

![image](https://github.com/jahir-raihan/calendar-generator/assets/76087446/2c4e822a-6246-4cd3-a4fb-5d2b57911fd2)

to this circular image

![image](https://github.com/jahir-raihan/calendar-generator/assets/76087446/d279b41e-f011-4028-95b1-8cc80d4c72d5)
